### PR TITLE
Add RoomController API specification and state sync event

### DIFF
--- a/app/Events/StateSynced.php
+++ b/app/Events/StateSynced.php
@@ -2,7 +2,7 @@
 
 namespace App\Events;
 
-use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
@@ -16,9 +16,19 @@ class StateSynced implements ShouldBroadcast
     {
     }
 
-    public function broadcastOn(): Channel
+    public function broadcastOn(): PresenceChannel
     {
-        return new Channel("room.{$this->roomId}");
+        return new PresenceChannel("room.{$this->roomId}");
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'state_sync';
+    }
+
+    public function broadcastWith(): array
+    {
+        return ['state' => $this->state];
     }
 }
 

--- a/app/Http/Controllers/Event/RoomController.php
+++ b/app/Http/Controllers/Event/RoomController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers\Event;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+/**
+ * Controller for managing Ultimate Tic-Tac-Toe rooms.
+ *
+ * All methods are server-authoritative and rely on Redis for state
+ * persistence. Implementation is intentionally left as TODO.
+ */
+class RoomController extends Controller
+{
+    /**
+     * Create a new room with an initial game state.
+     *
+     * TODO:
+     * - Generate a unique room identifier.
+     * - Build the initial GameState structure.
+     * - Persist the state to Redis under the room id.
+     * - Return response payload: { roomId, state }.
+     */
+    public function create()
+    {
+        // TODO: implement room creation logic.
+    }
+
+    /**
+     * Retrieve current game state for the given room id.
+     *
+     * @param  int  $roomId
+     *
+     * TODO:
+     * - Load state from Redis.
+     * - If state is missing, respond with 404.
+     * - Otherwise, return response payload: { state }.
+     */
+    public function get(int $roomId)
+    {
+        // TODO: implement state retrieval logic.
+    }
+
+    /**
+     * Join a room as a player or spectator.
+     *
+     * @param  Request  $request
+     * @param  int  $roomId
+     *
+     * TODO:
+     * - Assign symbol X or O to the first two unique users.
+     * - Additional unique users join as spectators.
+     * - Return updated state in payload: { state }.
+     */
+    public function join(Request $request, int $roomId)
+    {
+        // TODO: implement join logic.
+    }
+
+    /**
+     * Submit a move for the current player.
+     *
+     * @param  Request  $request
+     * @param  int  $roomId
+     *
+     * TODO:
+     * - Validate the move server-side.
+     * - Apply the move to the game state.
+     * - Persist updated state to Redis.
+     * - Broadcast `state_sync` event to other clients.
+     * - Return updated state in payload: { state }.
+     */
+    public function move(Request $request, int $roomId)
+    {
+        // TODO: implement move handling logic.
+    }
+
+    /**
+     * (Optional) Leave the room.
+     *
+     * @param  Request  $request
+     * @param  int  $roomId
+     *
+     * TODO:
+     * - Remove user from room participants.
+     * - Reassign player symbols if necessary.
+     * - Return updated state in payload: { state }.
+     */
+    public function leave(Request $request, int $roomId)
+    {
+        // TODO: implement leave logic.
+    }
+}
+

--- a/docs/room-controller-spec.md
+++ b/docs/room-controller-spec.md
@@ -1,0 +1,42 @@
+# RoomController API Contract
+
+Defines REST endpoints and the corresponding WebSocket event for
+synchronising Ultimate Tic-Tac-Toe rooms.
+
+## REST Endpoints
+
+### `POST /rooms`
+Create a new room.
+- **Response:** `{ "roomId": number, "state": GameState }`
+
+### `GET /rooms/{roomId}`
+Fetch current game state for the given room.
+- **404** when the room does not exist.
+- **Response:** `{ "state": GameState }`
+
+### `POST /rooms/{roomId}/join`
+Join the specified room.
+- First two unique users receive symbols **X** and **O**.
+- Additional users join as spectators.
+- **Response:** `{ "state": GameState }`
+
+### `POST /rooms/{roomId}/moves`
+Submit a move to the room.
+- Server validates the move and updates state.
+- Updated state is stored in Redis.
+- On success, a `state_sync` event is broadcast to other clients.
+- **Response:** `{ "state": GameState }`
+
+### `POST /rooms/{roomId}/leave` (optional)
+Leave the room and free the player's slot if necessary.
+- **Response:** `{ "state": GameState }`
+
+## WebSocket Event
+
+### `state_sync`
+Broadcast on presence channel `room.{roomId}`.
+
+Payload:
+```json
+{ "state": GameState }
+```


### PR DESCRIPTION
## Summary
- outline TODO-based Event\RoomController with create, get, join, move, and leave methods
- document REST endpoints and `state_sync` WebSocket event
- broadcast `StateSynced` on presence channel with `state_sync` name and state payload

## Testing
- `composer test` *(fails: Failed opening required vendor/autoload.php)*
- `composer install` *(fails: Required package "laravel/reverb" is not present in the lock file)*

------
https://chatgpt.com/codex/tasks/task_e_6899a5947bb8832f9ae1f1c53b39fdfc