### PR TITLE
feat: add server-side state management and validation

### DIFF
--- a/app/Http/Controllers/Game/RoomController.php
+++ b/app/Http/Controllers/Game/RoomController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Game;
 
-use App\Events\StateSynced;
 use App\Http\Controllers\Controller;
 use App\Services\Game\MoveValidator;
 use App\Services\Game\StateStore;
@@ -16,7 +15,7 @@ class RoomController extends Controller
 
     public function show(int $room)
     {
-        return response()->json($this->store->get($room));
+        return response()->json($this->store->getState($room));
     }
 
     public function storeMove(Request $request, int $room)
@@ -28,7 +27,7 @@ class RoomController extends Controller
             'cell.col' => 'required|integer|min:0',
         ]);
 
-        $state = $this->store->get($room);
+        $state = $this->store->getState($room);
         $move = [
             'mini' => ['row' => $data['mini']['row'], 'col' => $data['mini']['col']],
             'cell' => ['row' => $data['cell']['row'], 'col' => $data['cell']['col']],
@@ -41,7 +40,7 @@ class RoomController extends Controller
         }
 
         $state = $this->store->applyMove($room, $move);
-        broadcast(new StateSynced($room, $state))->toOthers();
+        $this->store->broadcastState($room, $state);
 
         return response()->json($state);
     }

--- a/app/Services/Game/MoveValidator.php
+++ b/app/Services/Game/MoveValidator.php
@@ -6,6 +6,18 @@ class MoveValidator
 {
     public function validate(array $state, array $move): bool
     {
+        if ($state['over']) {
+            return false;
+        }
+
+        if ($move['moveIndex'] !== $state['moveIndex'] + 1) {
+            return false;
+        }
+
+        if (($move['player'] ?? null) !== $state['current']) {
+            return false;
+        }
+
         $mega = $state['rules']['megaSize'];
         $mini = $state['rules']['miniSize'];
 
@@ -33,8 +45,11 @@ class MoveValidator
         }
 
         $active = $state['mega']['activeMini'];
-        if ($active && ($active['row'] !== $mr || $active['col'] !== $mc)) {
-            return false;
+        if ($active) {
+            $forced = $state['mega']['boards'][$active['row']][$active['col']];
+            if (! $forced['isClosed'] && ($active['row'] !== $mr || $active['col'] !== $mc)) {
+                return false;
+            }
         }
 
         return true;


### PR DESCRIPTION
## Summary
- add Redis-backed state helper with TTL and broadcasting
- expand move validation and game logic to handle winners and active boards
- wire controllers to new state APIs

## Testing
- `composer test` *(fails: require(/workspace/tic-tac-toe/vendor/autoload.php): Failed to open stream: No such file or directory)*
- `composer install` *(fails: Required package "laravel/reverb" is not present in the lock file)*


------
https://chatgpt.com/codex/tasks/task_e_6899a6ac120c832f8c725d91144c3087