### PR TITLE
Add API and UI scaffolding for multiplayer rooms

### DIFF
--- a/app/Http/Controllers/Game/RoomController.php
+++ b/app/Http/Controllers/Game/RoomController.php
@@ -13,12 +13,29 @@ class RoomController extends Controller
     {
     }
 
+    public function create()
+    {
+        $room = random_int(100000, 999999);
+        $state = $this->store->getState($room);
+        $this->store->saveState($room, $state);
+
+        return response()->json(['id' => $room, 'state' => $state]);
+    }
+
     public function show(int $room)
     {
         return response()->json($this->store->getState($room));
     }
 
-    public function storeMove(Request $request, int $room)
+    public function join(int $room)
+    {
+        $state = $this->store->getState($room);
+        $this->store->saveState($room, $state);
+
+        return response()->json($state);
+    }
+
+    public function move(Request $request, int $room)
     {
         $data = $request->validate([
             'mini.row' => 'required|integer|min:0',
@@ -43,6 +60,11 @@ class RoomController extends Controller
         $this->store->broadcastState($room, $state);
 
         return response()->json($state);
+    }
+
+    public function leave(int $room)
+    {
+        return response()->json(['left' => true]);
     }
 }
 

--- a/resources/js/pages/Home.vue
+++ b/resources/js/pages/Home.vue
@@ -1,9 +1,24 @@
 <template>
-  <div class="p-4">
-    <h2>Welcome to Ultimate Tic-Tac-Toe</h2>
+  <div class="p-4 space-y-4">
+    <Button @click="playOnline">Play Online</Button>
+    <Button @click="playLocal">Play Local</Button>
+    <Button @click="howTo">How to Play</Button>
   </div>
 </template>
 
 <script setup lang="ts">
-// Home page logic could go here.
+import { router } from '@inertiajs/vue3'
+import { Button } from '@/components/ui/button'
+
+function playOnline() {
+  router.visit('/lobby')
+}
+
+function playLocal() {
+  router.visit('/room/local')
+}
+
+function howTo() {
+  router.visit('/how-to')
+}
 </script>

--- a/resources/js/pages/Lobby.vue
+++ b/resources/js/pages/Lobby.vue
@@ -1,9 +1,65 @@
 <template>
-  <div class="p-4">
-    <h2>Game Lobby</h2>
+  <div class="p-4 space-y-6">
+    <div>
+      <Button @click="createRoom">Create Room</Button>
+    </div>
+
+    <form class="space-x-2" @submit.prevent="joinRoom">
+      <Input v-model="roomId" placeholder="Room ID" />
+      <Button type="submit">Join Room</Button>
+    </form>
+
+    <div v-if="recentRooms.length" class="mt-4">
+      <h3 class="mb-2">Recent Rooms</h3>
+      <ul class="list-disc pl-4">
+        <li v-for="r in recentRooms" :key="r">
+          <a href="#" @click.prevent="join(r)">{{ r }}</a>
+        </li>
+      </ul>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// Lobby management logic placeholder.
+import { ref, onMounted } from 'vue'
+import { router } from '@inertiajs/vue3'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+const roomId = ref('')
+const recentRooms = ref<string[]>([])
+
+onMounted(() => {
+  const stored = localStorage.getItem('recentRooms')
+  if (stored) {
+    recentRooms.value = JSON.parse(stored)
+  }
+})
+
+function persist() {
+  localStorage.setItem('recentRooms', JSON.stringify(recentRooms.value))
+}
+
+function addRecent(id: string) {
+  recentRooms.value = [id, ...recentRooms.value.filter(r => r !== id)].slice(0, 5)
+  persist()
+}
+
+async function createRoom() {
+  const res = await fetch('/api/rooms', { method: 'POST' })
+  const data = await res.json()
+  addRecent(String(data.id))
+  router.visit(`/room/${data.id}`)
+}
+
+function join(id: string) {
+  roomId.value = id
+  joinRoom()
+}
+
+function joinRoom() {
+  if (!roomId.value) return
+  addRecent(roomId.value)
+  router.visit(`/room/${roomId.value}`)
+}
 </script>

--- a/resources/js/pages/Profile.vue
+++ b/resources/js/pages/Profile.vue
@@ -1,9 +1,41 @@
 <template>
-  <div class="p-4">
-    <h2>User Profile</h2>
+  <div class="p-4 space-y-4">
+    <form class="space-y-4" @submit.prevent="save">
+      <div>
+        <Label for="nick">Nickname</Label>
+        <Input id="nick" v-model="nickname" class="mt-1" />
+      </div>
+      <div>
+        <Label for="avatar">Avatar</Label>
+        <input id="avatar" type="file" @change="onAvatar" class="mt-1" />
+      </div>
+      <Button type="submit">Save</Button>
+    </form>
+    <div v-if="preview" class="mt-4">
+      <img :src="preview" alt="avatar" class="w-16 h-16 rounded-full" />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// Profile management logic placeholder.
+import { ref } from 'vue'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+const nickname = ref('')
+const avatar = ref<File | null>(null)
+const preview = ref<string | null>(null)
+
+function onAvatar(e: Event) {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  avatar.value = file || null
+  if (file) {
+    preview.value = URL.createObjectURL(file)
+  }
+}
+
+function save() {
+  localStorage.setItem('profile', JSON.stringify({ nickname: nickname.value }))
+}
 </script>

--- a/resources/js/pages/Room.vue
+++ b/resources/js/pages/Room.vue
@@ -1,13 +1,52 @@
 <template>
-  <div class="p-4">
+  <div class="p-4 space-y-4">
     <TopBar />
+    <div class="space-y-1">
+      <p>Current: {{ state?.current }}</p>
+      <p>Active mini: {{ activeMini }}</p>
+      <p>Turn timer: {{ timer }}s</p>
+    </div>
     <GameCanvas />
-    <SidePanel />
+    <SidePanel class="flex gap-2">
+      <Button variant="destructive" @click="resign">Resign</Button>
+      <Button @click="rematch">Rematch</Button>
+    </SidePanel>
   </div>
 </template>
 
 <script setup lang="ts">
-import GameCanvas from '@/components/GameCanvas.vue';
-import SidePanel from '@/components/SidePanel.vue';
-import TopBar from '@/components/TopBar.vue';
+import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { router } from '@inertiajs/vue3'
+import GameCanvas from '@/components/GameCanvas.vue'
+import SidePanel from '@/components/SidePanel.vue'
+import TopBar from '@/components/TopBar.vue'
+import { Button } from '@/components/ui/button'
+
+const props = defineProps<{ room: string }>()
+
+const state = ref<any>(null)
+const timer = ref(0)
+let interval: ReturnType<typeof setInterval>
+
+onMounted(async () => {
+  const res = await fetch(`/api/rooms/${props.room}`)
+  state.value = await res.json()
+  interval = setInterval(() => timer.value++, 1000)
+})
+
+onUnmounted(() => clearInterval(interval))
+
+const activeMini = computed(() => {
+  if (!state.value || !state.value.mega.activeMini) return '-'
+  const { row, col } = state.value.mega.activeMini
+  return `${row},${col}`
+})
+
+function resign() {
+  console.log('resign')
+}
+
+function rematch() {
+  router.visit('/lobby')
+}
 </script>

--- a/resources/js/pages/Settings.vue
+++ b/resources/js/pages/Settings.vue
@@ -1,9 +1,36 @@
 <template>
-  <div class="p-4">
-    <h2>Settings</h2>
+  <div class="p-4 space-y-4">
+    <div>
+      <label class="block mb-1">Theme</label>
+      <select v-model="theme" class="border rounded p-1">
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+      </select>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <Checkbox id="sound" v-model="sound" />
+      <Label for="sound">Sound</Label>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <Checkbox id="vibration" v-model="vibration" />
+      <Label for="vibration">Vibration</Label>
+    </div>
+
+    <div class="mt-4">
+      <h3 class="font-semibold">Rules</h3>
+      <p class="text-sm">Read-only</p>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// Settings page logic placeholder.
+import { ref } from 'vue'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+
+const theme = ref('light')
+const sound = ref(true)
+const vibration = ref(true)
 </script>

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,9 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Game\RoomController;
 
 Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/rooms', [RoomController::class, 'create']);
     Route::get('/rooms/{room}', [RoomController::class, 'show']);
-    Route::post('/rooms/{room}/moves', [RoomController::class, 'storeMove']);
+    Route::post('/rooms/{room}/join', [RoomController::class, 'join']);
+    Route::post('/rooms/{room}/move', [RoomController::class, 'move']);
+    Route::post('/rooms/{room}/leave', [RoomController::class, 'leave']);
 });

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -4,4 +4,4 @@ use Illuminate\Support\Facades\Broadcast;
 
 Broadcast::channel('room.{roomId}', function ($user, $roomId) {
     return ['id' => $user->id, 'name' => $user->name];
-});
+}, ['guards' => ['web', 'sanctum']]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,8 +4,24 @@ use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
 Route::get('/', function () {
-    return Inertia::render('Welcome');
+    return Inertia::render('Home');
 })->name('home');
+
+Route::get('/lobby', function () {
+    return Inertia::render('Lobby');
+})->name('lobby');
+
+Route::get('/room/{room}', function (int $room) {
+    return Inertia::render('Room', ['room' => $room]);
+})->name('room');
+
+Route::get('/settings/game', function () {
+    return Inertia::render('Settings');
+})->name('settings');
+
+Route::get('/profile', function () {
+    return Inertia::render('Profile');
+})->name('profile');
 
 Route::get('dashboard', function () {
     return Inertia::render('Dashboard');


### PR DESCRIPTION
## Summary
- Wire up REST endpoints for creating, joining and playing in rooms
- Expose presence channel for room updates
- Add basic Home, Lobby, Room, Settings and Profile pages with navigation

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/tic-tac-toe/vendor/autoload.php')*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899aaff0d44832f8b38e37827e58beb