### PR TITLE
Fix Reverb environment variables for Echo

### DIFF
--- a/resources/js/Realtime/echo.ts
+++ b/resources/js/Realtime/echo.ts
@@ -6,10 +6,10 @@ import Pusher from 'pusher-js'
 
 export const echo = new Echo({
   broadcaster: 'reverb',
-  key: import.meta.env.VITE_REVERB_APP_KEY,
-  wsHost: import.meta.env.VITE_REVERB_HOST ?? window.location.hostname,
-  wsPort: Number(import.meta.env.VITE_REVERB_PORT) || 6001,
-  wssPort: Number(import.meta.env.VITE_REVERB_PORT) || 6001,
-  forceTLS: false,
+  key: import.meta.env.REVERB_APP_KEY,
+  wsHost: import.meta.env.REVERB_HOST ?? window.location.hostname,
+  wsPort: Number(import.meta.env.REVERB_PORT) || 6001,
+  wssPort: Number(import.meta.env.REVERB_PORT) || 6001,
+  forceTLS: import.meta.env.REVERB_SCHEME === 'https',
   enabledTransports: ['ws', 'wss'],
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+    envPrefix: ['VITE_', 'REVERB_'],
     plugins: [
         laravel({
             input: ['resources/js/app.ts'],


### PR DESCRIPTION
## Summary
- Read Reverb broadcasting settings from REVERB_* variables instead of VITE_*.
- Expose REVERB_* variables to the client via Vite envPrefix.

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `composer install` *(fails: Required package "laravel/reverb" not present in lock file; `composer update` blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899b3560a48832fb8c2dd7a3b0f2568