### PR TITLE
Fix local play button to create room via API

### DIFF
--- a/resources/js/pages/Home.vue
+++ b/resources/js/pages/Home.vue
@@ -14,8 +14,10 @@ function playOnline() {
   router.visit('/lobby')
 }
 
-function playLocal() {
-  router.visit('/room/local')
+async function playLocal() {
+  const res = await fetch('/api/rooms', { method: 'POST' })
+  const data = await res.json()
+  router.visit(`/room/${data.id}`)
 }
 
 function howTo() {


### PR DESCRIPTION
## Summary
- fix Play Local to create a game room through API instead of navigating to a non-existent `local` room

## Testing
- `npm run lint`
- `composer install` *(fails: Required package "laravel/reverb" is not present in the lock file)*
- `composer update` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899b5d2deac832fa22d6b49a38a6996