### PR TITLE
Integrate Ultimate Tic-Tac-Toe into dashboard with shadcn tabs

### DIFF
--- a/resources/js/Game/Phaser/GameScene.ts
+++ b/resources/js/Game/Phaser/GameScene.ts
@@ -1,52 +1,106 @@
-import Phaser from 'phaser'
-import { useGameStore } from '@/Stores/game'
+import { useGameStore } from '@/Stores/game';
+import Phaser from 'phaser';
 
 export default class GameScene extends Phaser.Scene {
-  private store = useGameStore()
-  private boardSize = 0
+    private store = useGameStore();
+    private boardSize = 0;
+    private marks!: Phaser.GameObjects.Graphics;
+    private activeMini: { row: number; col: number } | null = null;
+    private activeHighlight!: Phaser.GameObjects.Graphics;
+    private grid!: Phaser.GameObjects.Graphics;
 
-  constructor() {
-    super({ key: 'game' })
-  }
-
-  create() {
-    this.boardSize = Math.min(this.scale.width, this.scale.height)
-    this.drawGrid()
-
-    this.scale.on('resize', (gameSize: Phaser.Structs.Size) => {
-      this.boardSize = Math.min(gameSize.width, gameSize.height)
-      this.cameras.main.setViewport(0, 0, this.boardSize, this.boardSize)
-      this.drawGrid()
-    })
-
-    this.input.on('pointerdown', this.handlePointer, this)
-  }
-
-  private drawGrid() {
-    this.cameras.main.setBackgroundColor('#ffffff')
-    const g = this.add.graphics()
-    g.clear()
-    const cell = this.boardSize / 9
-    for (let i = 1; i < 9; i++) {
-      const thick = i % 3 === 0 ? 4 : 1
-      g.lineStyle(thick, 0x000000, 1)
-      g.moveTo(i * cell, 0)
-      g.lineTo(i * cell, this.boardSize)
-      g.moveTo(0, i * cell)
-      g.lineTo(this.boardSize, i * cell)
+    constructor() {
+        super({ key: 'game' });
     }
-    g.strokePath()
-  }
 
-  private handlePointer(pointer: Phaser.Input.Pointer) {
-    const cell = this.boardSize / 9
-    const miniRow = Math.floor(pointer.y / (cell * 3))
-    const miniCol = Math.floor(pointer.x / (cell * 3))
-    const cellRow = Math.floor((pointer.y % (cell * 3)) / cell)
-    const cellCol = Math.floor((pointer.x % (cell * 3)) / cell)
-    this.store.submitMove({
-      mini: { row: miniRow, col: miniCol },
-      cell: { row: cellRow, col: cellCol },
-    })
-  }
+    create() {
+        this.boardSize = Math.min(this.scale.width, this.scale.height);
+        this.grid = this.add.graphics();
+        this.marks = this.add.graphics();
+        this.activeHighlight = this.add.graphics();
+        this.drawGrid();
+        this.drawMarks();
+
+        this.store.$subscribe(() => {
+            this.drawMarks();
+        });
+
+        this.scale.on('resize', (gameSize: Phaser.Structs.Size) => {
+            this.boardSize = Math.min(gameSize.width, gameSize.height);
+            this.cameras.main.setViewport(0, 0, this.boardSize, this.boardSize);
+            this.drawGrid();
+            this.drawMarks();
+            this.highlightActiveMini();
+        });
+
+        this.input.on('pointerdown', this.handlePointer, this);
+    }
+
+    private drawGrid() {
+        this.cameras.main.setBackgroundColor('#ffffff');
+        const g = this.grid;
+        g.clear();
+        const cell = this.boardSize / 9;
+        for (let i = 1; i < 9; i++) {
+            const thick = i % 3 === 0 ? 4 : 1;
+            g.lineStyle(thick, 0x000000, 1);
+            g.moveTo(i * cell, 0);
+            g.lineTo(i * cell, this.boardSize);
+            g.moveTo(0, i * cell);
+            g.lineTo(this.boardSize, i * cell);
+        }
+        g.strokePath();
+    }
+
+    private handlePointer(pointer: Phaser.Input.Pointer) {
+        const cell = this.boardSize / 9;
+        const miniRow = Math.floor(pointer.y / (cell * 3));
+        const miniCol = Math.floor(pointer.x / (cell * 3));
+        const cellRow = Math.floor((pointer.y % (cell * 3)) / cell);
+        const cellCol = Math.floor((pointer.x % (cell * 3)) / cell);
+        if (this.activeMini && (miniRow !== this.activeMini.row || miniCol !== this.activeMini.col)) {
+            return;
+        }
+
+        this.store.playLocalMove({
+            mini: { row: miniRow, col: miniCol },
+            cell: { row: cellRow, col: cellCol },
+        });
+
+        this.activeMini = { row: cellRow, col: cellCol };
+        this.highlightActiveMini();
+        this.drawMarks();
+    }
+
+    private drawMarks() {
+        this.marks.clear();
+        const cell = this.boardSize / 9;
+        const moves = this.store.state?.moves || [];
+        moves.forEach((move: any) => {
+            const x = (move.mini.col * 3 + move.cell.col) * cell;
+            const y = (move.mini.row * 3 + move.cell.row) * cell;
+            if (move.player === 'X') {
+                this.marks.lineStyle(4, 0xe11d48, 1);
+                this.marks.beginPath();
+                this.marks.moveTo(x + cell * 0.2, y + cell * 0.2);
+                this.marks.lineTo(x + cell * 0.8, y + cell * 0.8);
+                this.marks.moveTo(x + cell * 0.8, y + cell * 0.2);
+                this.marks.lineTo(x + cell * 0.2, y + cell * 0.8);
+                this.marks.strokePath();
+            } else if (move.player === 'O') {
+                this.marks.lineStyle(4, 0x2563eb, 1);
+                this.marks.strokeCircle(x + cell / 2, y + cell / 2, cell * 0.3);
+            }
+        });
+    }
+
+    private highlightActiveMini() {
+        this.activeHighlight.clear();
+        if (!this.activeMini) return;
+        const cell = this.boardSize / 9;
+        const x = this.activeMini.col * cell * 3;
+        const y = this.activeMini.row * cell * 3;
+        this.activeHighlight.fillStyle(0x2563eb, 0.1);
+        this.activeHighlight.fillRect(x, y, cell * 3, cell * 3);
+    }
 }

--- a/resources/js/Stores/game/index.ts
+++ b/resources/js/Stores/game/index.ts
@@ -1,61 +1,64 @@
-import { defineStore } from 'pinia'
-import { useRoomStore } from '@/Stores/room'
+import { useRoomStore } from '@/Stores/room';
+import { defineStore } from 'pinia';
 
 export interface MovePayload {
-  mini: { row: number; col: number }
-  cell: { row: number; col: number }
+    mini: { row: number; col: number };
+    cell: { row: number; col: number };
 }
 
 export const useGameStore = defineStore('game', {
-  state: () => ({
-    state: null as any,
-    pending: false,
-    error: null as string | null,
-  }),
-  actions: {
-    async fetchState(roomId: string) {
-      this.pending = true
-      this.error = null
-      try {
-        const res = await fetch(`/api/rooms/${roomId}`)
-        this.state = await res.json()
-      } catch (e: any) {
-        this.error = e.message
-      } finally {
-        this.pending = false
-      }
+    state: () => ({
+        state: null as any,
+        pending: false,
+        error: null as string | null,
+    }),
+    actions: {
+        async fetchState(roomId: string) {
+            this.pending = true;
+            this.error = null;
+            try {
+                const res = await fetch(`/api/rooms/${roomId}`);
+                this.state = await res.json();
+            } catch (e: any) {
+                this.error = e.message;
+            } finally {
+                this.pending = false;
+            }
+        },
+        async submitMove(payload: MovePayload) {
+            const room = useRoomStore();
+            if (!room.roomId) return;
+            this.pending = true;
+            this.error = null;
+            try {
+                const res = await fetch(`/api/rooms/${room.roomId}/move`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                const data = await res.json();
+                if (!res.ok) {
+                    this.error = data.message || 'Invalid move';
+                    return;
+                }
+                this.state = data;
+            } catch (e: any) {
+                this.error = e.message;
+            } finally {
+                this.pending = false;
+            }
+        },
+        applyStateSync(state: any) {
+            this.state = state;
+        },
+        playLocalMove(payload: MovePayload & { player?: 'X' | 'O' }) {
+            // For hot-seat play without server
+            this.state = this.state || { moves: [] };
+            if (!this.state.moves) this.state.moves = [];
+
+            const player = payload.player || (this.state.moves.length % 2 === 0 ? 'X' : 'O');
+
+            this.state.moves.push({ ...payload, player });
+        },
     },
-    async submitMove(payload: MovePayload) {
-      const room = useRoomStore()
-      if (!room.roomId) return
-      this.pending = true
-      this.error = null
-      try {
-        const res = await fetch(`/api/rooms/${room.roomId}/move`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-        })
-        const data = await res.json()
-        if (!res.ok) {
-          this.error = data.message || 'Invalid move'
-          return
-        }
-        this.state = data
-      } catch (e: any) {
-        this.error = e.message
-      } finally {
-        this.pending = false
-      }
-    },
-    applyStateSync(state: any) {
-      this.state = state
-    },
-    playLocalMove(payload: MovePayload & { player?: 'X' | 'O' }) {
-      // For hot-seat play without server
-      this.state = this.state || {}
-      if (!this.state.moves) this.state.moves = []
-      this.state.moves.push(payload)
-    },
-  },
-})
+});

--- a/resources/js/components/ui/tabs/Tabs.vue
+++ b/resources/js/components/ui/tabs/Tabs.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { TabsRoot, type TabsRootEmits, type TabsRootProps, useForwardPropsEmits } from 'reka-ui'
+
+const props = defineProps<TabsRootProps>()
+const emits = defineEmits<TabsRootEmits>()
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <TabsRoot data-slot="tabs" v-bind="forwarded" class="w-full">
+    <slot />
+  </TabsRoot>
+</template>
+

--- a/resources/js/components/ui/tabs/TabsContent.vue
+++ b/resources/js/components/ui/tabs/TabsContent.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { TabsContent, type TabsContentProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<TabsContentProps & { class?: string }>()
+</script>
+
+<template>
+  <TabsContent
+    data-slot="tabs-content"
+    v-bind="props"
+    :class="cn('mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring focus-visible:ring-offset-2', props.class)"
+  >
+    <slot />
+  </TabsContent>
+</template>
+

--- a/resources/js/components/ui/tabs/TabsList.vue
+++ b/resources/js/components/ui/tabs/TabsList.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { TabsList, type TabsListProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<TabsListProps & { class?: string }>()
+</script>
+
+<template>
+  <TabsList
+    data-slot="tabs-list"
+    v-bind="props"
+    :class="cn('inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground', props.class)"
+  >
+    <slot />
+  </TabsList>
+</template>
+

--- a/resources/js/components/ui/tabs/TabsTrigger.vue
+++ b/resources/js/components/ui/tabs/TabsTrigger.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { TabsTrigger, type TabsTriggerProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<TabsTriggerProps & { class?: string }>()
+</script>
+
+<template>
+  <TabsTrigger
+    data-slot="tabs-trigger"
+    v-bind="props"
+    :class="
+      cn(
+        'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+        props.class,
+      )
+    "
+  >
+    <slot />
+  </TabsTrigger>
+</template>
+

--- a/resources/js/components/ui/tabs/index.ts
+++ b/resources/js/components/ui/tabs/index.ts
@@ -1,0 +1,5 @@
+export { default as Tabs } from './Tabs.vue'
+export { default as TabsList } from './TabsList.vue'
+export { default as TabsTrigger } from './TabsTrigger.vue'
+export { default as TabsContent } from './TabsContent.vue'
+

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import GameCanvas from '@/components/GameCanvas.vue';
+import Heading from '@/components/Heading.vue';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/vue3';
@@ -16,21 +19,40 @@ const breadcrumbs: BreadcrumbItem[] = [
     <Head title="Dashboard" />
 
     <AppLayout :breadcrumbs="breadcrumbs">
-        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4 overflow-x-auto">
-            <div class="grid auto-rows-min gap-4 md:grid-cols-3">
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
-                </div>
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
-                </div>
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
-                </div>
-            </div>
-            <div class="relative min-h-[100vh] flex-1 rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
-                <PlaceholderPattern />
-            </div>
+        <div class="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
+            <Tabs default-value="overview" class="flex h-full flex-1 flex-col">
+                <TabsList class="mb-4 grid w-full grid-cols-2">
+                    <TabsTrigger value="overview">Overview</TabsTrigger>
+                    <TabsTrigger value="game">Play</TabsTrigger>
+                </TabsList>
+                <TabsContent value="overview" class="flex flex-1 flex-col gap-4">
+                    <div class="grid auto-rows-min gap-4 md:grid-cols-3">
+                        <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
+                            <PlaceholderPattern />
+                        </div>
+                        <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
+                            <PlaceholderPattern />
+                        </div>
+                        <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
+                            <PlaceholderPattern />
+                        </div>
+                    </div>
+                    <div class="relative min-h-[100vh] flex-1 rounded-xl border border-sidebar-border/70 md:min-h-min dark:border-sidebar-border">
+                        <PlaceholderPattern />
+                    </div>
+                </TabsContent>
+                <TabsContent value="game" class="flex-1">
+                    <div class="flex h-full flex-col gap-4 md:flex-row">
+                        <div class="space-y-4 md:w-1/2">
+                            <Heading title="Ultimate Tic-Tac-Toe" description="Play the classic game with a twist." />
+                            <p class="text-sm text-muted-foreground">Click a cell to make your move.</p>
+                        </div>
+                        <div class="relative aspect-square flex-1 rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
+                            <GameCanvas />
+                        </div>
+                    </div>
+                </TabsContent>
+            </Tabs>
         </div>
     </AppLayout>
 </template>


### PR DESCRIPTION
## Summary
- Add reusable shadcn-style Tabs components.
- Embed Ultimate Tic-Tac-Toe in a new **Play** tab on the dashboard.
- Enhance Phaser scene to render X/O marks and highlight active mini boards while tracking players locally.

## Testing
- `npm run lint`
- `php artisan test` *(fails: Missing vendor dependencies)*
- `composer install` *(fails: lock file out of sync)*
- `composer update` *(fails: CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899c1a0c454832fb367b73b224a1cce